### PR TITLE
CR-757 Add FormType and QuestionnaireType

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
@@ -138,7 +138,8 @@ public class CaseServiceClientServiceImpl {
 
     log.with("caseId", caseId)
         .with("questionnaireId", newQuestionnaireId.getQuestionnaireId())
-        .with("uac", newQuestionnaireId.getUac())
+        .with("formType", newQuestionnaireId.getFormType())
+        .with("questionnaireType", newQuestionnaireId.getQuestionnaireId())
         .debug("getNewQuestionnaireIdForCase() generated new questionnaireId");
 
     return newQuestionnaireId;

--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/SingleUseQuestionnaireIdDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/SingleUseQuestionnaireIdDTO.java
@@ -10,4 +10,6 @@ public class SingleUseQuestionnaireIdDTO {
 
   private String questionnaireId;
   private String uac;
+  private String formType;
+  private String questionnaireType;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
@@ -98,7 +98,10 @@ public class CaseServiceClientServiceImplTest {
     SingleUseQuestionnaireIdDTO results =
         caseServiceClientService.getSingleUseQuestionnaireId(testUuid, true, UUID.randomUUID());
 
-    assertEquals("8823938628", results.getQuestionnaireId());
+    assertEquals(resultsFromCaseService.getQuestionnaireId(), results.getQuestionnaireId());
+    assertEquals(resultsFromCaseService.getUac(), results.getUac());
+    assertEquals(resultsFromCaseService.getFormType(), results.getFormType());
+    assertEquals(resultsFromCaseService.getQuestionnaireType(), results.getQuestionnaireType());
   }
 
   private void doTestGetCaseById(boolean requireCaseEvents) throws Exception {

--- a/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.SingleUseQuestionnaireIdDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.SingleUseQuestionnaireIdDTO.json
@@ -1,6 +1,8 @@
 [
 {
   "questionnaireId": "8823938628",
-  "uac": "cfea54bc-8ae3-4311-9cdd-e29e9877cd2f"
+  "uac": "b7565b5e-1396-4965-91a2-918c0d3642ed",
+  "formType": "H",
+  "questionnaireType": "1"
 }
 ]


### PR DESCRIPTION
# Motivation and Context
Simple change to add FormType and QuestionnaireType to the response for a request to the RM Case service endpoint for the url /cases/{caseId}/qid to get a new questionnaire Id for telephone capture. Attributes are taken as String and not checked in any way allowing RM complete flexibility to change this API as required in future, we will simply pass through as attribute returned to caller.

# What has changed
Addition of required fields to SingleUseQuestionnaireDTO.

# How to test?
Unit test amended to include required fields.