### PR TITLE
Add handDelivery field to the CaseContainerDTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/CaseContainerDTO.java
@@ -61,4 +61,6 @@ public class CaseContainerDTO {
   private String region;
 
   private String surveyType;
+
+  private boolean handDelivery;
 }


### PR DESCRIPTION
This  change is required because RM are adding a new field to their case api service this sprint (starting 11/2/20)

The new field name in RM Case API response is 'handDelivery' and it is a boolean.