### PR TITLE
add addressType to CaseContainerDTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/CaseContainerDTO.java
@@ -58,6 +58,8 @@ public class CaseContainerDTO {
 
   private String caseType;
 
+  private String addressType;
+
   private String region;
 
   private String surveyType;


### PR DESCRIPTION
The addressType field now exists in the RM case service so I have added it to CaseContainerDTO as required.