### PR TITLE
CR-770 Field Service to pass formType to EQ

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/QuestionnaireIdDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/model/QuestionnaireIdDTO.java
@@ -9,4 +9,5 @@ public class QuestionnaireIdDTO {
 
   private String questionnaireId;
   private boolean active;
+  private String formType;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
@@ -75,7 +75,9 @@ public class CaseServiceClientServiceImplTest {
     // Run the request
     QuestionnaireIdDTO results = caseServiceClientService.getReusableQuestionnaireId(testUuid);
 
-    assertEquals("1110000009", results.getQuestionnaireId());
+    assertEquals(resultsFromCaseService.getQuestionnaireId(), results.getQuestionnaireId());
+    assertEquals(resultsFromCaseService.getFormType(), results.getFormType());
+    assertEquals(resultsFromCaseService.isActive(), results.isActive());
   }
 
   @Test

--- a/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.QuestionnaireIdDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.QuestionnaireIdDTO.json
@@ -1,5 +1,7 @@
 [
 {
-  "questionnaireId": "1110000009"
+  "questionnaireId": "1110000009",
+  "active": true,
+  "formType": "H"
 }
 ]


### PR DESCRIPTION
# Motivation and Context
Formtype is hard coded when the Field service calls EQ. It is now to be provided by the RM case-api service and passed to EQ by the Field service launch endpoint by use of the QuestionnaireIdDTO.

# What has changed
QuestionnaireIdDTO formType attribute added.

# How to test?
Unit test amended to include formType.