### PR TITLE
CR-981 getCaseByUprn should always have validAddressOnly set

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
@@ -51,6 +51,7 @@ public class CaseServiceClientServiceImpl {
     // Build map for query params
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("caseEvents", Boolean.toString(listCaseEvents));
+    queryParams.add("validAddressOnly", Boolean.TRUE.toString());
 
     // Ask Case Service to find case details
     List<CaseContainerDTO> cases =

--- a/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
@@ -206,8 +206,9 @@ public class CaseServiceClientServiceImplTest {
     Mockito.verify(restClient)
         .getResources(any(), any(), any(), queryParamsCaptor.capture(), any());
     MultiValueMap<String, String> queryParams = queryParamsCaptor.getValue();
+    assertEquals(2, queryParams.keySet().size());
     assertEquals("[" + requireCaseEvents + "]", queryParams.get("caseEvents").toString());
-    assertEquals(1, queryParams.keySet().size());
+    assertEquals("[true]", queryParams.get("validAddressOnly").toString());
   }
 
   @Test


### PR DESCRIPTION
CR-981 requires the "validAddressOnly" parameter to be set to true when calling RM.  Trivial change.