### PR TITLE
Cr 744 - add method to access the findCCSCasesByPostcode endpoint

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImpl.java
@@ -19,6 +19,7 @@ public class CaseServiceClientServiceImpl {
   private static final String CASE_BY_CASE_REFERENCE_QUERY_PATH = "/cases/ref/{reference}";
   private static final String CASE_GET_REUSABLE_QUESTIONNAIRE_ID_PATH = "/cases/ccs/{caseId}/qid";
   private static final String CASE_CREATE_SINGLE_USE_QUESTIONNAIRE_ID_PATH = "/cases/{caseId}/qid";
+  private static final String CCS_CASE_BY_POSTCODE_QUERY_PATH = "/cases/ccs/postcode/{postcode}";
 
   private RestClient caseServiceClient;
 
@@ -63,6 +64,20 @@ public class CaseServiceClientServiceImpl {
             Long.toString(uprn));
 
     log.with("uprn", uprn).debug("getCaseByUprn() found case details by Uprn");
+
+    return cases;
+  }
+
+  public List<CaseContainerDTO> getCcsCaseByPostcode(String postcode) {
+    log.with("postcode", postcode)
+        .debug("getCcsCaseByPostcode() calling Case Service to find ccs case details by postcode");
+
+    // Ask Case Service to find ccs case details
+    List<CaseContainerDTO> cases =
+        caseServiceClient.getResources(
+            CCS_CASE_BY_POSTCODE_QUERY_PATH, CaseContainerDTO[].class, null, null, postcode);
+
+    log.with("postcode", postcode).debug("getCaseByPostcode() found ccs case details by postcode");
 
     return cases;
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/caseapiclient/caseservice/CaseServiceClientServiceImplTest.java
@@ -157,8 +157,8 @@ public class CaseServiceClientServiceImplTest {
 
     // Sanity check the response
     assertEquals(testUuid, results.getId());
-    assertNotNull(
-        results.getCaseEvents()); // Response will have events as not removed at this level
+    assertNotNull(results.getCaseEvents()); // Response will have events as not removed at this
+    // level
     verifyRequestUsedCaseEventsQueryParam(requireCaseEvents);
     return results;
   }
@@ -171,6 +171,11 @@ public class CaseServiceClientServiceImplTest {
   @Test
   public void testGetCaseByUprn_withNoCaseEvents() throws Exception {
     doTestGetCaseByUprn(false);
+  }
+
+  @Test
+  public void testGetCcsCaseByPostcode() {
+    doTestGetCcsCaseByPostcode();
   }
 
   private void doTestGetCaseByUprn(boolean requireCaseEvents) throws Exception {
@@ -211,6 +216,33 @@ public class CaseServiceClientServiceImplTest {
     assertEquals("[true]", queryParams.get("validAddressOnly").toString());
   }
 
+  private void doTestGetCcsCaseByPostcode() {
+    String caseId1 = "b7565b5e-1396-4965-91a2-918c0d3642ed";
+    String caseId2 = "b7565b5e-2222-2222-2222-918c0d3642ed";
+    String postcode = "G1 2AA";
+
+    // Build results to be returned by the case service
+    List<CaseContainerDTO> caseData = FixtureHelper.loadClassFixtures(CaseContainerDTO[].class);
+    Mockito.when(
+            restClient.getResources(
+                eq("/cases/ccs/postcode/{postcode}"),
+                eq(CaseContainerDTO[].class),
+                any(),
+                any(),
+                eq(postcode)))
+        .thenReturn(caseData);
+
+    // Run the request
+    List<CaseContainerDTO> results = caseServiceClientService.getCcsCaseByPostcode(postcode);
+
+    // Sanity check the response
+    assertEquals(UUID.fromString(caseId1), results.get(0).getId());
+    assertEquals(postcode, results.get(0).getPostcode());
+
+    assertEquals(UUID.fromString(caseId2), results.get(1).getId());
+    assertEquals(postcode, results.get(1).getPostcode());
+  }
+
   @Test
   public void testGetCaseByCaseRef_withCaseEvents() throws Exception {
     doTestGetCaseByCaseRef(true);
@@ -244,8 +276,8 @@ public class CaseServiceClientServiceImplTest {
     // Sanity check the response
     assertEquals(Long.toString(testCaseRef), results.getCaseRef());
     assertEquals(testUuid, results.getId());
-    assertNotNull(
-        results.getCaseEvents()); // Response will have events as not removed at this level
+    assertNotNull(results.getCaseEvents()); // Response will have events as not removed at this
+    // level
     verifyRequestUsedCaseEventsQueryParam(requireCaseEvents);
   }
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change to the case api client is required in order to access the following RM endpoint, which also exists in the mock case service:

@GetMapping(value = "/ccs/postcode/{postcode}")
  public List<CaseContainerDTO> findCcsCasesByPostcode(
      @PathVariable("postcode") String postcode,
      @RequestParam(value = "caseEvents", required = false, defaultValue = "false")
          boolean caseEvents);

# What has changed
<!--- What code changes has been made -->
The following method, and a corresponding JUnit test, have been added to the case api client:

public ResponseEntity<CaseDTO> getCCSCaseByPostcode(
      @PathVariable(value = "postcode") @NotBlank @Pattern(regexp = Constants.POSTCODE_RE)
          final String postcode);

# How to test?
<!--- Describe in detail how you tested your changes. -->
Run the JUnit test named testGetCcsCaseByPostcode(), which is in class CaseServiceClientServiceImplTest